### PR TITLE
Refactor DPI scaling and update configuration files

### DIFF
--- a/GIMI/Core/Debugger/Debugger.ini
+++ b/GIMI/Core/Debugger/Debugger.ini
@@ -152,9 +152,8 @@ local $bak_z = z
 local $bak_w = w
 run = CommandListPassWindowInfo
 z = gs-cb13
-; Set w to 0 in case this is an old 3DMigoto without effective_dpi support
-w = 0
-w = 0
+; Pass reported DPI to calculate required scaling
+w = effective_dpi
 ; Font is passed into the pixel shader (to draw it) *and* the geometry shader
 ; (as the character sizes are encoded in the final character of the font):
 gs-t100 = ResourceCBFont

--- a/GIMI/Core/GIMI/KeyBindings.ini
+++ b/GIMI/Core/GIMI/KeyBindings.ini
@@ -7,9 +7,6 @@ Key = no_modifiers F6
 $costume_mods = 0,1
 type = cycle
 
-; [KeyToggleCompatibilityMode]
-; key = ALT F12
-; run = CommandListToggleCompatibilityMode
 
 [KeyToggleUserGuide]
 key = no_modifiers F12
@@ -21,7 +18,8 @@ key = CTRL F12
 type = cycle
 $show_hunting_mode_guide = 0,1
 
-; [KeyHideNotification]
-; key = X
-; key = XB_X
-; run = CommandListHideNotification
+[KeyHideFirstRunNotification]
+Key = no_modifiers F10
+condition = $first_run == 1
+type = cycle
+$first_run = 0,1

--- a/GIMI/Core/GIMI/Libraries/Offset.ini
+++ b/GIMI/Core/GIMI/Libraries/Offset.ini
@@ -1,5 +1,6 @@
 namespace = global\offset
-; OffsetFix.ini Version 3.9.3
+; OffsetFix.ini Version 3.9.4
+; - Fixed a bug where the face offset was not being applied
 ; - Removing support for /ShaderFixes files
 ; - Upgraded to a regex based system
 
@@ -24,16 +25,21 @@ namespace = global\offset
 [CommandListOffset]
 if DRAW_TYPE != 1
 	x169 = $offset
-	x170 = $offset
+	x170 = 0
 	x171 = 1
 	$active = 1
 endif
 
 [CommandListOffsetFace]
+if DRAW_TYPE != 1
+	x169 = $offset
+	x170 = 0
+	x171 = 1
 	$faceActive = 1
+endif
 
 [CommandListCheck]
-if $active == 1
+if $active == 1 || $faceActive == 1
 	post $active = 0
 	post $faceActive = 0
 	post x169 = 0

--- a/GIMI/Core/GIMI/Libraries/Region.ini
+++ b/GIMI/Core/GIMI/Libraries/Region.ini
@@ -23,7 +23,10 @@ namespace = global\region
 ; 10: teapot
 ; 11: chenyu
 ; 12: natlan
-
+;------------------------
+;Update Log
+;Ver 0.2.1: Fix Natlan tp hash
+;------------------------
 [Constants]
 global $mondstadt = 0
 global $liyue = 0
@@ -644,7 +647,7 @@ $chenyu = 1
 
 ;Detect Natlan
 [TextureOverrideLSNatlanTPScreen]
-hash = 453f6cee
+hash = 66196151
 run = CommandListResetValues
 match_priority = 0
 $natlan = 1

--- a/GIMI/Core/GIMI/main.ini
+++ b/GIMI/Core/GIMI/main.ini
@@ -9,7 +9,7 @@ include = Libraries\Includes.ini
 
 ; Constants -------------------------
 [Constants]
-global $version = 8.08
+global $version = 8.09
 
 ; Used for text output if autodetection fails
 global $window_width = 1920
@@ -26,7 +26,7 @@ run = CommandListRenderGUI
 
 [ResourceVersionNotification]
 type = Buffer
-data = "GIMI 8.0.8 (PRESS F12 TO SHOW GUIDE)"
+data = "GIMI 8.0.9 (PRESS F12 TO SHOW GUIDE)"
 
 ; Shader overrides -----------------------------------------
 ; This is very inefficient hence is limited to the most common resources
@@ -97,8 +97,11 @@ endif
 ; Backup used IniParams
 local $bak_x = x
 local $bak_y = y
+local $bak_w = w
 ; Pass window size in a fail-safe way
 run = CommandListPassWindowInfo
+; Pass reported DPI to calculate required scaling
+w = effective_dpi
 ; Calculate positions of all chars
 run = CustomShaderFormatText
 ; Renter formatted text
@@ -106,6 +109,7 @@ run = CustomShaderRenderText
 ; Restore IniParams:
 x = $bak_x
 y = $bak_y
+w = $bak_w
 
 [CustomShaderFormatText]
 ; The compute shader scans the text and breaks it up into smaller chunks for
@@ -211,7 +215,6 @@ if time < 30
     run = CommandListPrintText
     if $first_run
         $show_user_guide = 1
-        $first_run = 0
     endif
 endif
 

--- a/GIMI/d3dx.ini
+++ b/GIMI/d3dx.ini
@@ -507,6 +507,12 @@ allow_check_interface = 1
 allow_create_device = 1
 allow_platform_update = 1
 
+; Delay in seconds for initial config reload after game start. Set to -1 to disable if not required.
+config_initialization_delay = 0
+; Time in seconds between writing persistent vars to d3dx_user.ini. Set to -1 to disable if not required.
+settings_auto_save_interval = 60
+
+
 ;------------------------------------------------------------------------------------------------------
 ; Settings to force display device to a specific mode.
 ; Uncomment a value to force the specific setting.


### PR DESCRIPTION
Refactor the DPI scaling logic in the text printer and debugger. Update configuration files for hotfixes and add default values for initialization delay and auto-save interval. Bump version number.